### PR TITLE
move to flu-theme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,8 +3,10 @@ import 'dart:developer';
 import 'package:flupresso/service_locator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
 import 'ui/homepage.dart';
 import 'package:wakelock/wakelock.dart';
+import 'package:flupresso/ui/theme.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -15,22 +17,23 @@ void main() {
     log('Failed to set wakelock: ' + e.toString());
   }
 
-  runApp(MyApp());
+  runApp(MultiProvider(providers: [
+    ChangeNotifierProvider<FluTheme>(create: (_) => FluTheme()),
+  ], child: MyApp()));
 }
 
 class MyApp extends StatelessWidget {
-  MyApp(){
+  MyApp() {
     setupServices();
   }
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
+    final theme = Provider.of<FluTheme>(context);
+
     return MaterialApp(
       title: 'Flupresso',
-      theme: ThemeData(
-        visualDensity: VisualDensity.adaptivePlatformDensity,
-      ),
+      theme: theme.themeData,
       home: HomePage(title: 'Flupresso'),
     );
   }

--- a/lib/model/profile.dart
+++ b/lib/model/profile.dart
@@ -28,8 +28,8 @@ class ProfileFrame {
     return ProfileFrame(
       json['name'] as String,
       json['index'] as int,
-      double.parse(json['temp'].toString()),
-      double.parse(json['duration'].toString()),
+      json['temp'].toDouble(),
+      json['duration'].toDouble(),
       ProfileTarget.fromJson(json['target']),
     );
   }
@@ -89,7 +89,7 @@ class ProfileTrigger {
 
   factory ProfileTrigger.fromJson(dynamic json) {
     return ProfileTrigger(
-      double.parse(json['value'].toString()),
+      json['value'].toDouble(),
       json['type'] as ProfileType,
       _$enumDecode(_$ProfileTriggerType, json['operator']),
     );

--- a/lib/model/profile.dart
+++ b/lib/model/profile.dart
@@ -63,7 +63,7 @@ class ProfileTarget {
 
   factory ProfileTarget.fromJson(dynamic json) {
     return ProfileTarget(
-      double.parse(json['value'].toString()),
+      json['value'].toDouble(),
       _$enumDecode(_$ProfileType, json['type']),
       json['interpolate'] as bool,
     );

--- a/lib/model/profile.dart
+++ b/lib/model/profile.dart
@@ -18,7 +18,7 @@ class ProfileFrame {
   String name;
   int frameNumber;
   double temperature;
-  int duration;
+  double duration;
   ProfileTarget target;
 
   ProfileFrame(this.name, this.frameNumber, this.temperature, this.duration,
@@ -28,8 +28,8 @@ class ProfileFrame {
     return ProfileFrame(
       json['name'] as String,
       json['index'] as int,
-      json['temp'] as double,
-      json['duration'] as int,
+      double.parse(json['temp'].toString()),
+      double.parse(json['duration'].toString()),
       ProfileTarget.fromJson(json['target']),
     );
   }
@@ -63,7 +63,7 @@ class ProfileTarget {
 
   factory ProfileTarget.fromJson(dynamic json) {
     return ProfileTarget(
-      json['value'] as double,
+      double.parse(json['value'].toString()),
       _$enumDecode(_$ProfileType, json['type']),
       json['interpolate'] as bool,
     );
@@ -89,7 +89,7 @@ class ProfileTrigger {
 
   factory ProfileTrigger.fromJson(dynamic json) {
     return ProfileTrigger(
-      json['value'] as double,
+      double.parse(json['value'].toString()),
       json['type'] as ProfileType,
       _$enumDecode(_$ProfileTriggerType, json['operator']),
     );

--- a/lib/model/services/state/profile_service.dart
+++ b/lib/model/services/state/profile_service.dart
@@ -13,7 +13,7 @@ class ProfileService extends ChangeNotifier {
       "name": "Infuse",
       "index": 0,
       "temp": 90.0,
-      "duration": 7,
+      "duration": 7.0,
       "target": {
         "value": 5.0,
         "type": "flow",
@@ -29,7 +29,7 @@ class ProfileService extends ChangeNotifier {
       "name": "Brew",
       "index": 1,
       "temp": 95.0,
-      "duration": 10,
+      "duration": 10.0,
       "target": {
         "value": 2.0,
         "type": "flow",
@@ -45,7 +45,7 @@ class ProfileService extends ChangeNotifier {
       "name": "Brew",
       "index": 2,
       "temp": 90.0,
-      "duration": 5,
+      "duration": 5.0,
       "target": {
         "value": 2.0,
         "type": "flow",
@@ -55,10 +55,10 @@ class ProfileService extends ChangeNotifier {
     {
       "name": "Brew",
       "index": 3,
-      "temp": 90.0,
+      "temp": 90,
       "duration": 2,
       "target": {
-        "value": 4.0,
+        "value": 4,
         "type": "flow",
         "interpolate": false
       }
@@ -67,7 +67,7 @@ class ProfileService extends ChangeNotifier {
       "name": "Brew",
       "index": 4,
       "temp": 90.0,
-      "duration": 10,
+      "duration": 10.0,
       "target": {
         "value": 2.0,
         "type": "flow",

--- a/lib/ui/homepage.dart
+++ b/lib/ui/homepage.dart
@@ -6,7 +6,6 @@ import 'package:flupresso/ui/screens/water_screen.dart';
 import 'package:flupresso/ui/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'theme.dart' as theme;
 
 class HomePage extends StatefulWidget {
   HomePage({Key key, this.title}) : super(key: key);

--- a/lib/ui/homepage.dart
+++ b/lib/ui/homepage.dart
@@ -3,7 +3,9 @@ import 'package:flupresso/model/services/state/profile_service.dart';
 import 'package:flupresso/service_locator.dart';
 import 'package:flupresso/ui/screens/coffee_screen.dart';
 import 'package:flupresso/ui/screens/water_screen.dart';
+import 'package:flupresso/ui/theme.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'theme.dart' as theme;
 
 class HomePage extends StatefulWidget {
@@ -34,16 +36,15 @@ class _HomePageState extends State<HomePage> {
     });
   }
 
-  Widget _buildButton(child, onpress) {
-    var color = theme.Colors.backgroundColor;
+  Widget _buildButton(FluTheme theme, child, onpress) {
     return Container(
         padding: EdgeInsets.all(10.0),
         child: FlatButton(
           onPressed: onpress,
-          color: color,
+          color: theme.backgroundColor,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(19.0),
-            side: BorderSide(color: color),
+            side: BorderSide(color: theme.backgroundColor),
           ),
           child: Container(
             height: 50,
@@ -55,6 +56,8 @@ class _HomePageState extends State<HomePage> {
 
   @override
   Widget build(BuildContext context) {
+    var theme = Provider.of<FluTheme>(context);
+
     Widget coffee;
     var currentCoffee = coffeeSelection.currentCoffee;
     if (currentCoffee != null) {
@@ -64,14 +67,14 @@ class _HomePageState extends State<HomePage> {
         ),
         Text(
           currentCoffee.roaster,
-          style: theme.TextStyles.tabSecondary,
+          style: theme.tabSecondaryStyle,
         ),
         Spacer(
           flex: 1,
         ),
         Text(
           currentCoffee.name,
-          style: theme.TextStyles.tabSecondary,
+          style: theme.tabSecondaryStyle,
         ),
         Spacer(
           flex: 2,
@@ -80,7 +83,7 @@ class _HomePageState extends State<HomePage> {
     } else {
       coffee = Text(
         'No Coffee selected',
-        style: theme.TextStyles.tabSecondary,
+        style: theme.tabSecondaryStyle,
       );
     }
     Widget profile;
@@ -88,19 +91,19 @@ class _HomePageState extends State<HomePage> {
     if (currentProfile != null) {
       profile = Text(
         currentProfile.name,
-        style: theme.TextStyles.tabSecondary,
+        style: theme.tabSecondaryStyle,
       );
     } else {
       profile = Text(
         'No Profile selected',
-        style: theme.TextStyles.tabSecondary,
+        style: theme.tabSecondaryStyle,
       );
     }
 
     return Scaffold(
       body: Container(
         decoration: BoxDecoration(
-          gradient: theme.Colors.screenBackground,
+          gradient: theme.screenBackgroundGradient,
         ),
         child: Column(
           children: <Widget>[
@@ -111,7 +114,7 @@ class _HomePageState extends State<HomePage> {
                 child: Image(
               image: AssetImage('assets/decent.png'),
               height: 120,
-              color: theme.Colors.primaryColor,
+              color: theme.primaryColor,
             )),
             Spacer(
               flex: 3,
@@ -128,9 +131,10 @@ class _HomePageState extends State<HomePage> {
                 alignment: WrapAlignment.center,
                 children: [
                   _buildButton(
+                    theme,
                     Text(
                       'Espresso',
-                      style: theme.TextStyles.tabSecondary,
+                      style: theme.tabSecondaryStyle,
                     ),
                     () => Navigator.push(
                         context,
@@ -139,9 +143,10 @@ class _HomePageState extends State<HomePage> {
                         )),
                   ),
                   _buildButton(
+                    theme,
                     Text(
                       'Water / Steam / Flush',
-                      style: theme.TextStyles.tabSecondary,
+                      style: theme.tabSecondaryStyle,
                     ),
                     () => Navigator.push(
                       context,
@@ -151,9 +156,10 @@ class _HomePageState extends State<HomePage> {
                     ),
                   ),
                   _buildButton(
+                    theme,
                       Text(
                         'Settings',
-                        style: theme.TextStyles.tabSecondary,
+                        style: theme.tabSecondaryStyle,
                       ),
                       () => {}),
                 ],

--- a/lib/ui/screens/coffee_screen.dart
+++ b/lib/ui/screens/coffee_screen.dart
@@ -8,7 +8,6 @@ import 'package:charts_flutter/flutter.dart' as charts;
 import 'package:flupresso/ui/screens/coffee_selection.dart';
 import 'package:flupresso/ui/screens/machine_selection.dart';
 import 'package:flutter/material.dart';
-import 'package:flupresso/ui/theme.dart' as theme;
 import 'package:provider/provider.dart';
 
 import '../theme.dart';

--- a/lib/ui/screens/coffee_screen.dart
+++ b/lib/ui/screens/coffee_screen.dart
@@ -9,6 +9,9 @@ import 'package:flupresso/ui/screens/coffee_selection.dart';
 import 'package:flupresso/ui/screens/machine_selection.dart';
 import 'package:flutter/material.dart';
 import 'package:flupresso/ui/theme.dart' as theme;
+import 'package:provider/provider.dart';
+
+import '../theme.dart';
 
 class CoffeeScreen extends StatefulWidget {
   @override
@@ -61,14 +64,14 @@ class _CoffeeScreenState extends State<CoffeeScreen> {
   List<ShotState> dataPoints = [];
   double baseTime;
 
-  List<charts.Series<ShotState, double>> _createData() {
+  List<charts.Series<ShotState, double>> _createData(FluTheme theme) {
     return [
       charts.Series<ShotState, double>(
         id: 'Pressure',
         domainFn: (ShotState point, _) => point.sampleTime,
         measureFn: (ShotState point, _) => point.groupPressure,
         colorFn: (_, __) =>
-            charts.ColorUtil.fromDartColor(theme.Colors.backgroundColor),
+            charts.ColorUtil.fromDartColor(theme.backgroundColor),
         strokeWidthPxFn: (_, __) => 3,
         data: dataPoints,
       ),
@@ -77,25 +80,25 @@ class _CoffeeScreenState extends State<CoffeeScreen> {
         domainFn: (ShotState point, _) => point.sampleTime,
         measureFn: (ShotState point, _) => point.groupFlow,
         colorFn: (_, __) =>
-            charts.ColorUtil.fromDartColor(theme.Colors.secondaryColor),
+            charts.ColorUtil.fromDartColor(theme.secondaryColor),
         strokeWidthPxFn: (_, __) => 3,
         data: dataPoints,
       ),
     ];
   }
 
-  Widget _buildGraph() {
+  Widget _buildGraph(FluTheme theme) {
     return Container(
       height: 300,
       margin: const EdgeInsets.only(left: 10.0),
       width: MediaQuery.of(context).size.width - 105,
       decoration: BoxDecoration(
-        color: theme.Colors.tabColor,
+        color: theme.tabColor,
         shape: BoxShape.rectangle,
         borderRadius: BorderRadius.circular(8.0),
       ),
       child: charts.LineChart(
-        _createData(),
+        _createData(theme),
         animate: true,
         behaviors: [
           // Define one domain and two measure annotations configured to render
@@ -113,11 +116,11 @@ class _CoffeeScreenState extends State<CoffeeScreen> {
             labelStyle: charts.TextStyleSpec(
                 fontSize: 10,
                 color:
-                    charts.ColorUtil.fromDartColor(theme.Colors.primaryColor)),
+                    charts.ColorUtil.fromDartColor(theme.primaryColor)),
             lineStyle: charts.LineStyleSpec(
                 thickness: 0,
                 color:
-                    charts.ColorUtil.fromDartColor(theme.Colors.primaryColor)),
+                    charts.ColorUtil.fromDartColor(theme.primaryColor)),
           ),
         ),
         domainAxis: charts.NumericAxisSpec(
@@ -125,76 +128,76 @@ class _CoffeeScreenState extends State<CoffeeScreen> {
             labelStyle: charts.TextStyleSpec(
                 fontSize: 10,
                 color:
-                    charts.ColorUtil.fromDartColor(theme.Colors.primaryColor)),
+                    charts.ColorUtil.fromDartColor(theme.primaryColor)),
             lineStyle: charts.LineStyleSpec(
                 thickness: 0,
                 color:
-                    charts.ColorUtil.fromDartColor(theme.Colors.primaryColor)),
+                    charts.ColorUtil.fromDartColor(theme.primaryColor)),
           ),
         ),
       ),
     );
   }
 
-  Widget _buildLiveInsights() {
+  Widget _buildLiveInsights(FluTheme theme) {
     Widget insights;
     if (machineService.state.shot != null) {
       insights = Column(
         children: [
           Row(
             children: [
-              Text('State: ', style: theme.TextStyles.tabSecondary),
+              Text('State: ', style: theme.tabSecondaryStyle),
               Text(
                   machineService.state.coffeeState
                       .toString()
                       .substring(12)
                       .toUpperCase(),
-                  style: theme.TextStyles.tabPrimary),
+                  style: theme.tabPrimaryStyle),
             ],
           ),
           Row(
             children: [
-              Text('Pressure: ', style: theme.TextStyles.tabSecondary),
+              Text('Pressure: ', style: theme.tabSecondaryStyle),
               Text(
                   machineService.state.shot.groupPressure.toStringAsFixed(1) +
                       ' bar',
-                  style: theme.TextStyles.tabPrimary),
+                  style: theme.tabPrimaryStyle),
             ],
           ),
           Row(
             children: [
-              Text('Flow: ', style: theme.TextStyles.tabSecondary),
+              Text('Flow: ', style: theme.tabSecondaryStyle),
               Text(
                   machineService.state.shot.groupFlow.toStringAsFixed(2) +
                       ' ml/s',
-                  style: theme.TextStyles.tabPrimary),
+                  style: theme.tabPrimaryStyle),
             ],
           ),
           Row(
             children: [
-              Text('Mix Temp: ', style: theme.TextStyles.tabSecondary),
+              Text('Mix Temp: ', style: theme.tabSecondaryStyle),
               Text(machineService.state.shot.mixTemp.toStringAsFixed(2) + ' °C',
-                  style: theme.TextStyles.tabPrimary),
+                  style: theme.tabPrimaryStyle),
             ],
           ),
           Row(
             children: [
-              Text('Head Temp: ', style: theme.TextStyles.tabSecondary),
+              Text('Head Temp: ', style: theme.tabSecondaryStyle),
               Text(
                   machineService.state.shot.headTemp.toStringAsFixed(2) + ' °C',
-                  style: theme.TextStyles.tabPrimary),
+                  style: theme.tabPrimaryStyle),
             ],
           ),
         ],
       );
     } else {
       insights =
-          Text('Machine is not connected', style: theme.TextStyles.tabPrimary);
+          Text('Machine is not connected', style: theme.tabPrimaryStyle);
     }
     return insights;
   }
 
-  Row _buildScaleInsight() {
+  Row _buildScaleInsight(FluTheme theme) {
     return Row(
       children: [
         Spacer(),
@@ -207,16 +210,16 @@ class _CoffeeScreenState extends State<CoffeeScreen> {
               children: <Widget>[
                 Row(
                   children: [
-                    Text('Weight: ', style: theme.TextStyles.tabSecondary),
+                    Text('Weight: ', style: theme.tabSecondaryStyle),
                     Text(snapshot.data.weight.toStringAsFixed(2) + 'g',
-                        style: theme.TextStyles.tabSecondary),
+                        style: theme.tabSecondaryStyle),
                   ],
                 ),
                 Row(
                   children: [
-                    Text('Flow: ', style: theme.TextStyles.tabSecondary),
+                    Text('Flow: ', style: theme.tabSecondaryStyle),
                     Text(snapshot.data.flow.toStringAsFixed(2) + 'g/s',
-                        style: theme.TextStyles.tabSecondary)
+                        style: theme.tabSecondaryStyle)
                   ],
                 ),
               ],
@@ -232,23 +235,25 @@ class _CoffeeScreenState extends State<CoffeeScreen> {
 
   @override
   Widget build(BuildContext context) {
+    var theme = Provider.of<FluTheme>(context);
+
     return DefaultTabController(
       length: 3,
       child: Scaffold(
         appBar: AppBar(
-          backgroundColor: theme.Colors.backgroundColor,
+          backgroundColor: theme.backgroundColor,
           title: Row(
             children: [
-              Text('Coffee', style: theme.TextStyles.tabSecondary),
+              Text('Coffee', style: theme.tabSecondaryStyle),
               Container(
                 width: 30,
               ),
               Flexible(
                 child: RaisedButton(
-                  textColor: theme.Colors.primaryColor,
+                  textColor: theme.primaryColor,
                   color: pressAttention
-                      ? theme.Colors.goodColor
-                      : theme.Colors.badColor,
+                      ? theme.goodColor
+                      : theme.badColor,
                   onPressed: () =>
                       setState(() => pressAttention = !pressAttention),
                   child: pressAttention ? Text('Start') : Text('Stop'),
@@ -263,26 +268,26 @@ class _CoffeeScreenState extends State<CoffeeScreen> {
             indicatorSize: TabBarIndicatorSize.tab,
             indicator: BubbleTabIndicator(
               indicatorHeight: 25.0,
-              indicatorColor: theme.Colors.tabColor,
+              indicatorColor: theme.tabColor,
               tabBarIndicatorSize: TabBarIndicatorSize.tab,
             ),
             tabs: [
               Tab(
                 child: Text(
                   'Live',
-                  style: theme.TextStyles.tabLabel,
+                  style: theme.tabLabelStyle,
                 ),
               ),
               Tab(
                 child: Text(
                   'Settings',
-                  style: theme.TextStyles.tabLabel,
+                  style: theme.tabLabelStyle,
                 ),
               ),
               Tab(
                 child: Text(
                   'History',
-                  style: theme.TextStyles.tabLabel,
+                  style: theme.tabLabelStyle,
                 ),
               ),
             ],
@@ -292,26 +297,26 @@ class _CoffeeScreenState extends State<CoffeeScreen> {
           children: [
             Container(
               decoration: BoxDecoration(
-                gradient: theme.Colors.screenBackground,
+                gradient: theme.screenBackgroundGradient,
               ),
               child: Column(
                 children: <Widget>[
-                  _buildLiveInsights(),
-                  theme.Helper.horizontalBorder(),
-                  _buildScaleInsight(),
-                  _buildGraph(),
+                  _buildLiveInsights(theme),
+                  theme.buildHorizontalBorder(),
+                  _buildScaleInsight(theme),
+                  _buildGraph(theme),
                 ],
               ),
             ),
             Container(
               decoration: BoxDecoration(
-                gradient: theme.Colors.screenBackground,
+                gradient: theme.screenBackgroundGradient,
               ),
               child: CoffeeSelectionTab(),
             ),
             Container(
               decoration: BoxDecoration(
-                gradient: theme.Colors.screenBackground,
+                gradient: theme.screenBackgroundGradient,
               ),
               child: MachineSelectionTab(),
             ),

--- a/lib/ui/screens/coffee_selection.dart
+++ b/lib/ui/screens/coffee_selection.dart
@@ -3,7 +3,6 @@ import 'package:flupresso/model/services/state/coffee_service.dart';
 import 'package:flupresso/model/services/state/machine_service.dart';
 import 'package:flupresso/service_locator.dart';
 import 'package:flutter/material.dart';
-import 'package:flupresso/ui/theme.dart' as theme;
 import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'package:provider/provider.dart';
 

--- a/lib/ui/screens/coffee_selection.dart
+++ b/lib/ui/screens/coffee_selection.dart
@@ -5,6 +5,9 @@ import 'package:flupresso/service_locator.dart';
 import 'package:flutter/material.dart';
 import 'package:flupresso/ui/theme.dart' as theme;
 import 'package:flutter_typeahead/flutter_typeahead.dart';
+import 'package:provider/provider.dart';
+
+import '../theme.dart';
 
 class CoffeeSelection {
   Widget getTabContent() {
@@ -19,13 +22,14 @@ class CoffeeSelection {
 class CoffeeSelectionImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    var theme = Provider.of<FluTheme>(context);
     return Center(
       child: CachedNetworkImage(
         imageUrl:
             'https://images.squarespace-cdn.com/content/5d318463e8d6c50001d160a6/1563541579731-9HESYR1NGT92L2CWRJ3X/elemenza_Logo_BoA.png?format=1500w&content-type=image%2Fpng',
         width: 65,
         height: 65,
-        color: theme.Colors.primaryColor,
+        color: theme.primaryColor,
         fit: BoxFit.scaleDown,
       ),
     );
@@ -58,6 +62,8 @@ class _CoffeeSelectionTabState extends State<CoffeeSelectionTab> {
 
   @override
   Widget build(BuildContext context) {
+    var theme = Provider.of<FluTheme>(context);
+
     return Container(
       margin: const EdgeInsets.only(left: 95.0),
       child: Column(
@@ -67,7 +73,7 @@ class _CoffeeSelectionTabState extends State<CoffeeSelectionTab> {
             textFieldConfiguration: TextFieldConfiguration(
               decoration: InputDecoration(
                 labelText: 'Roaster',
-                labelStyle: theme.TextStyles.tabLabel,
+                labelStyle: theme.tabLabelStyle,
                 contentPadding: EdgeInsets.zero,
                 border: InputBorder.none,
                 focusedBorder: InputBorder.none,
@@ -75,7 +81,7 @@ class _CoffeeSelectionTabState extends State<CoffeeSelectionTab> {
                 errorBorder: InputBorder.none,
                 disabledBorder: InputBorder.none,
               ),
-              style: theme.TextStyles.tabPrimary,
+              style: theme.tabPrimaryStyle,
               controller: _typeAheadRoasterController,
             ),
             suggestionsCallback: (pattern) async {
@@ -104,7 +110,7 @@ class _CoffeeSelectionTabState extends State<CoffeeSelectionTab> {
             textFieldConfiguration: TextFieldConfiguration(
                 decoration: InputDecoration(
                   labelText: 'Coffee',
-                  labelStyle: theme.TextStyles.tabLabel,
+                  labelStyle: theme.tabLabelStyle,
                   contentPadding: EdgeInsets.zero,
                   border: InputBorder.none,
                   focusedBorder: InputBorder.none,
@@ -113,7 +119,7 @@ class _CoffeeSelectionTabState extends State<CoffeeSelectionTab> {
                   disabledBorder: InputBorder.none,
                 ),
                 controller: _typeAheadCoffeeController,
-                style: theme.TextStyles.tabSecondary),
+                style: theme.tabSecondaryStyle),
             suggestionsCallback: (pattern) async {
               return coffeeService.getCoffeeSuggestions(
                   pattern, _selectedRoaster);
@@ -138,19 +144,19 @@ class _CoffeeSelectionTabState extends State<CoffeeSelectionTab> {
             //onSaved: (value) => this._selectedCoffee = value,
           ),
           Container(
-              color: theme.Colors.backgroundColor,
+              color: theme.backgroundColor,
               width: 24.0,
               height: 1.0,
               margin: const EdgeInsets.symmetric(vertical: 8.0)),
           Row(
             children: <Widget>[
               Icon(Icons.location_on,
-                  size: 14.0, color: theme.Colors.goodColor),
-              Text('Dummy Origin', style: theme.TextStyles.tabTertiary),
+                  size: 14.0, color: theme.goodColor),
+              Text('Dummy Origin', style: theme.tabTertiaryStyle),
               Container(width: 24.0),
               Icon(Icons.flight_land,
-                  size: 14.0, color: theme.Colors.goodColor),
-              Text('10€', style: theme.TextStyles.tabTertiary),
+                  size: 14.0, color: theme.goodColor),
+              Text('10€', style: theme.tabTertiaryStyle),
             ],
           ),
         ],

--- a/lib/ui/screens/machine_selection.dart
+++ b/lib/ui/screens/machine_selection.dart
@@ -1,6 +1,5 @@
 import 'package:flupresso/model/services/state/machine_service.dart';
 import 'package:flutter/material.dart';
-import 'package:flupresso/ui/theme.dart' as theme;
 import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'package:provider/provider.dart';
 

--- a/lib/ui/screens/machine_selection.dart
+++ b/lib/ui/screens/machine_selection.dart
@@ -2,6 +2,9 @@ import 'package:flupresso/model/services/state/machine_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flupresso/ui/theme.dart' as theme;
 import 'package:flutter_typeahead/flutter_typeahead.dart';
+import 'package:provider/provider.dart';
+
+import '../theme.dart';
 
 class MachineSelection {}
 
@@ -21,6 +24,8 @@ class _MachineSelectionTabState extends State<MachineSelectionTab> {
 
   @override
   Widget build(BuildContext context) {
+    var theme = Provider.of<FluTheme>(context);
+
     return Container(
       margin: const EdgeInsets.only(left: 95.0),
       child: Column(
@@ -30,7 +35,7 @@ class _MachineSelectionTabState extends State<MachineSelectionTab> {
             textFieldConfiguration: TextFieldConfiguration(
               decoration: InputDecoration(
                 labelText: 'Manufacturer',
-                labelStyle: theme.TextStyles.tabLabel,
+                labelStyle: theme.tabLabelStyle,
                 contentPadding: EdgeInsets.zero,
                 border: InputBorder.none,
                 focusedBorder: InputBorder.none,
@@ -38,7 +43,7 @@ class _MachineSelectionTabState extends State<MachineSelectionTab> {
                 errorBorder: InputBorder.none,
                 disabledBorder: InputBorder.none,
               ),
-              style: theme.TextStyles.tabPrimary,
+              style: theme.tabPrimaryStyle,
               controller: _typeAheadManufacturerController,
             ),
             suggestionsCallback: (pattern) async {
@@ -68,7 +73,7 @@ class _MachineSelectionTabState extends State<MachineSelectionTab> {
             textFieldConfiguration: TextFieldConfiguration(
                 decoration: InputDecoration(
                   labelText: 'Model',
-                  labelStyle: theme.TextStyles.tabLabel,
+                  labelStyle: theme.tabLabelStyle,
                   contentPadding: EdgeInsets.zero,
                   border: InputBorder.none,
                   focusedBorder: InputBorder.none,
@@ -77,7 +82,7 @@ class _MachineSelectionTabState extends State<MachineSelectionTab> {
                   disabledBorder: InputBorder.none,
                 ),
                 controller: _typeAheadModelController,
-                style: theme.TextStyles.tabSecondary),
+                style: theme.tabSecondaryStyle),
             suggestionsCallback: (pattern) async {
               return MachineService.getModellSuggestions(
                   pattern, _selectedManufacturer);
@@ -103,7 +108,7 @@ class _MachineSelectionTabState extends State<MachineSelectionTab> {
             //onSaved: (value) => this._selectedModel = value,
           ),
           Container(
-              color: theme.Colors.backgroundColor,
+              color: theme.backgroundColor,
               width: 24.0,
               height: 1.0,
               margin: const EdgeInsets.symmetric(vertical: 8.0)),

--- a/lib/ui/screens/water_screen.dart
+++ b/lib/ui/screens/water_screen.dart
@@ -3,7 +3,6 @@ import 'package:flupresso/model/services/ble/scale_service.dart';
 import 'package:flupresso/service_locator.dart';
 import 'package:charts_flutter/flutter.dart' as charts;
 import 'package:flutter/material.dart';
-import 'package:flupresso/ui/theme.dart' as theme;
 import 'package:provider/provider.dart';
 
 import '../theme.dart';

--- a/lib/ui/screens/water_screen.dart
+++ b/lib/ui/screens/water_screen.dart
@@ -4,6 +4,9 @@ import 'package:flupresso/service_locator.dart';
 import 'package:charts_flutter/flutter.dart' as charts;
 import 'package:flutter/material.dart';
 import 'package:flupresso/ui/theme.dart' as theme;
+import 'package:provider/provider.dart';
+
+import '../theme.dart';
 
 class WaterScreen extends StatefulWidget {
   @override
@@ -33,14 +36,14 @@ class _WaterScreenState extends State<WaterScreen> {
 
   List<ShotState> dataPoints = [];
 
-  List<charts.Series<ShotState, double>> _createData() {
+  List<charts.Series<ShotState, double>> _createData(FluTheme theme) {
     return [
       charts.Series<ShotState, double>(
         id: 'Pressure',
         domainFn: (ShotState point, _) => point.sampleTime,
         measureFn: (ShotState point, _) => point.groupPressure,
         colorFn: (_, __) =>
-            charts.ColorUtil.fromDartColor(theme.Colors.backgroundColor),
+            charts.ColorUtil.fromDartColor(theme.backgroundColor),
         strokeWidthPxFn: (_, __) => 3,
         data: dataPoints,
       ),
@@ -49,25 +52,25 @@ class _WaterScreenState extends State<WaterScreen> {
         domainFn: (ShotState point, _) => point.sampleTime,
         measureFn: (ShotState point, _) => point.groupFlow,
         colorFn: (_, __) =>
-            charts.ColorUtil.fromDartColor(theme.Colors.secondaryColor),
+            charts.ColorUtil.fromDartColor(theme.secondaryColor),
         strokeWidthPxFn: (_, __) => 3,
         data: dataPoints,
       ),
     ];
   }
 
-  Widget _buildWaterControl() {
+  Widget _buildWaterControl(FluTheme theme) {
     return ButtonBar(
       children: [
         Text(
           'Water:',
-          style: theme.TextStyles.tabPrimary,
+          style: theme.tabPrimaryStyle,
         ),
         RaisedButton(
-          color: theme.Colors.goodColor,
+          color: theme.goodColor,
           child: Text(
             '-5',
-            style: theme.TextStyles.tabSecondary,
+            style: theme.tabSecondaryStyle,
           ),
           onPressed: () {
             setState(() {
@@ -88,10 +91,10 @@ class _WaterScreenState extends State<WaterScreen> {
           },
         ),
         RaisedButton(
-          color: theme.Colors.goodColor,
+          color: theme.goodColor,
           child: Text(
             '+5',
-            style: theme.TextStyles.tabSecondary,
+            style: theme.tabSecondaryStyle,
           ),
           onPressed: () {
             setState(() {
@@ -105,18 +108,18 @@ class _WaterScreenState extends State<WaterScreen> {
     );
   }
 
-  Widget _buildSteamConrol() {
+  Widget _buildSteamConrol(FluTheme theme) {
     return ButtonBar(
       children: [
         Text(
           'Steam Timeout: ',
-          style: theme.TextStyles.tabPrimary,
+          style: theme.tabPrimaryStyle,
         ),
         RaisedButton(
-          color: theme.Colors.goodColor,
+          color: theme.goodColor,
           child: Text(
             '-1',
-            style: theme.TextStyles.tabSecondary,
+            style: theme.tabSecondaryStyle,
           ),
           onPressed: () {
             setState(() {
@@ -137,10 +140,10 @@ class _WaterScreenState extends State<WaterScreen> {
           },
         ),
         RaisedButton(
-          color: theme.Colors.goodColor,
+          color: theme.goodColor,
           child: Text(
             '+1',
-            style: theme.TextStyles.tabSecondary,
+            style: theme.tabSecondaryStyle,
           ),
           onPressed: () {
             setState(() {
@@ -154,18 +157,18 @@ class _WaterScreenState extends State<WaterScreen> {
     );
   }
 
-  Widget _buildTemperaturControl() {
+  Widget _buildTemperaturControl(FluTheme theme) {
     return ButtonBar(
       children: [
         Text(
           'Water Temperature: ',
-          style: theme.TextStyles.tabPrimary,
+          style: theme.tabPrimaryStyle,
         ),
         RaisedButton(
-          color: theme.Colors.goodColor,
+          color: theme.goodColor,
           child: Text(
             '-1',
-            style: theme.TextStyles.tabSecondary,
+            style: theme.tabSecondaryStyle,
           ),
           onPressed: () {
             setState(() {
@@ -186,10 +189,10 @@ class _WaterScreenState extends State<WaterScreen> {
           },
         ),
         RaisedButton(
-          color: theme.Colors.goodColor,
+          color: theme.goodColor,
           child: Text(
             '+1',
-            style: theme.TextStyles.tabSecondary,
+            style: theme.tabSecondaryStyle,
           ),
           onPressed: () {
             setState(() {
@@ -203,18 +206,18 @@ class _WaterScreenState extends State<WaterScreen> {
     );
   }
 
-  Widget _buildFlushControl() {
+  Widget _buildFlushControl(FluTheme theme) {
     return ButtonBar(
       children: [
         Text(
           'Flush Timeout: ',
-          style: theme.TextStyles.tabPrimary,
+          style: theme.tabPrimaryStyle,
         ),
         RaisedButton(
-          color: theme.Colors.goodColor,
+          color: theme.goodColor,
           child: Text(
             '-1',
-            style: theme.TextStyles.tabSecondary,
+            style: theme.tabSecondaryStyle,
           ),
           onPressed: () {
             setState(() {
@@ -235,10 +238,10 @@ class _WaterScreenState extends State<WaterScreen> {
           },
         ),
         RaisedButton(
-          color: theme.Colors.goodColor,
+          color: theme.goodColor,
           child: Text(
             '+1',
-            style: theme.TextStyles.tabSecondary,
+            style: theme.tabSecondaryStyle,
           ),
           onPressed: () {
             setState(() {
@@ -252,18 +255,18 @@ class _WaterScreenState extends State<WaterScreen> {
     );
   }
 
-  Widget _buildGraph() {
+  Widget _buildGraph(FluTheme theme) {
     return Container(
       height: 150,
       margin: const EdgeInsets.only(left: 10.0),
       width: MediaQuery.of(context).size.width * 0.75,
       decoration: BoxDecoration(
-        color: theme.Colors.tabColor,
+        color: theme.tabColor,
         shape: BoxShape.rectangle,
         borderRadius: BorderRadius.circular(8.0),
       ),
       child: charts.LineChart(
-        _createData(),
+        _createData(theme),
         animate: true,
         behaviors: [],
         primaryMeasureAxis: charts.NumericAxisSpec(
@@ -286,19 +289,19 @@ class _WaterScreenState extends State<WaterScreen> {
     );
   }
 
-  Widget _buildControls() {
+  Widget _buildControls(FluTheme theme) {
     return Row(
       children: [
         Spacer(
           flex: 5,
         ),
         RaisedButton(
-          textColor: theme.Colors.primaryColor,
-          color: theme.Colors.goodColor,
+          textColor: theme.primaryColor,
+          color: theme.goodColor,
           onPressed: () => setState(() => {}),
           child: Text(
             'Water',
-            style: theme.TextStyles.tabTertiary,
+            style: theme.tabTertiaryStyle,
           ),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(30.0),
@@ -308,12 +311,12 @@ class _WaterScreenState extends State<WaterScreen> {
           flex: 1,
         ),
         RaisedButton(
-          textColor: theme.Colors.primaryColor,
-          color: theme.Colors.goodColor,
+          textColor: theme.primaryColor,
+          color: theme.goodColor,
           onPressed: () => setState(() => {}),
           child: Text(
             'Steam',
-            style: theme.TextStyles.tabTertiary,
+            style: theme.tabTertiaryStyle,
           ),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(30.0),
@@ -323,12 +326,12 @@ class _WaterScreenState extends State<WaterScreen> {
           flex: 1,
         ),
         RaisedButton(
-          textColor: theme.Colors.primaryColor,
-          color: theme.Colors.goodColor,
+          textColor: theme.primaryColor,
+          color: theme.goodColor,
           onPressed: () => setState(() => {}),
           child: Text(
             'Flush',
-            style: theme.TextStyles.tabTertiary,
+            style: theme.tabTertiaryStyle,
           ),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(30.0),
@@ -343,30 +346,32 @@ class _WaterScreenState extends State<WaterScreen> {
 
   @override
   Widget build(BuildContext context) {
+    var theme = Provider.of<FluTheme>(context);
+
     return Scaffold(
       appBar: AppBar(
-        backgroundColor: theme.Colors.backgroundColor,
+        backgroundColor: theme.backgroundColor,
         title:
-            Text('Water / Steam / Flush', style: theme.TextStyles.tabSecondary),
+            Text('Water / Steam / Flush', style: theme.tabSecondaryStyle),
       ),
       body: Container(
         decoration: BoxDecoration(
-          gradient: theme.Colors.screenBackground,
+          gradient: theme.screenBackgroundGradient,
         ),
         child: ListView(
           children: <Widget>[
-            _buildGraph(),
-            theme.Helper.horizontalBorder(),
+            _buildGraph(theme),
+            theme.buildHorizontalBorder(),
             Center(
-              child: _buildControls(),
+              child: _buildControls(theme),
             ),
-            theme.Helper.horizontalBorder(),
-            _buildTemperaturControl(),
-            _buildWaterControl(),
-            theme.Helper.horizontalBorder(),
-            _buildFlushControl(),
-            theme.Helper.horizontalBorder(),
-            _buildSteamConrol(),
+            theme.buildHorizontalBorder(),
+            _buildTemperaturControl(theme),
+            _buildWaterControl(theme),
+            theme.buildHorizontalBorder(),
+            _buildFlushControl(theme),
+            theme.buildHorizontalBorder(),
+            _buildSteamConrol(theme),
             Container(
               height: 40,
             ),

--- a/lib/ui/theme.dart
+++ b/lib/ui/theme.dart
@@ -1,88 +1,87 @@
 import 'package:flutter/material.dart';
 
-class Colors {
-  const Colors();
+class FluTheme extends ChangeNotifier {
+  var primaryColor = Color(0xFFFFFFFF);
+  var secondaryColor = Color(0xFFF2C230);
+  var backgroundColor = Color(0xFF184059);
+  var tabImageBorder = Color(0xFFFFFFFF);
+  var goodColor = Color(0xFF32C2F0);
+  var badColor = Color(0xFFF28030);
 
-  static const Color primaryColor = Color(0xFFFFFFFF); //Color(0xFFFFFFFF);
-  static const Color secondaryColor = Color(0xFFF2C230);
-  static const Color goodColor = Color(0xFF32C2F0);
-  static const Color badColor = Color(0xFFF28030);
+  Color tabColor;
+  LinearGradient screenBackgroundGradient;
+  TextStyle tabPrimaryStyle;
+  TextStyle tabSecondaryStyle;
+  TextStyle tabTertiaryStyle;
+  TextStyle tabLabelStyle;
 
-  static const Color backgroundColor = Color(0xFF184059); //0xFFFF4580
-  static const Color tabImageBorder = Color(0xFFFFFFFF); // 0xFFFFD2CF
-  static final Color tabImageShadowColor =
-      HSLColor.fromColor(backgroundColor).withLightness(0.7).toColor();
-  static final Color tabShadowColor =
-      HSLColor.fromColor(backgroundColor).withLightness(1).toColor();
+  FluTheme() {
+    var value = HSVColor.fromColor(backgroundColor).value;
+    var top = HSVColor.fromColor(backgroundColor).withValue(value - .05).toColor();
+    var bottom = HSVColor.fromColor(backgroundColor).withValue(value - .1).toColor();
 
-  static final Color tabColor =
-      HSVColor.fromColor(backgroundColor).withValue(_value - .05).toColor();
+    // generate tab and background from our background color
+    tabColor = HSVColor.fromColor(backgroundColor).withValue(value - .05).toColor();
+    screenBackgroundGradient = LinearGradient(
+      colors: [
+        top,
+        backgroundColor,
+        backgroundColor,
+        bottom,
+      ],
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      stops: [0.0, 0.15, 0.4, 1.0],
+      tileMode: TileMode.clamp,
+    );
 
-  static final _value = HSVColor.fromColor(backgroundColor).value;
-  static final _top =
-      HSVColor.fromColor(backgroundColor).withValue(_value - .05).toColor();
-  static final _bottom =
-      HSVColor.fromColor(backgroundColor).withValue(_value - .1).toColor();
+    tabPrimaryStyle =
+        TextStyle(color: primaryColor, fontFamily: 'Poppins', fontWeight: FontWeight.w300, fontSize: 28.0);
+    tabSecondaryStyle =
+        TextStyle(color: primaryColor, fontFamily: 'Poppins', fontWeight: FontWeight.w300, fontSize: 20.0);
+    tabTertiaryStyle =
+        TextStyle(color: primaryColor, fontFamily: 'Poppins', fontWeight: FontWeight.w300, fontSize: 16.0);
+    tabLabelStyle = TextStyle(color: primaryColor, fontFamily: 'Poppins', fontWeight: FontWeight.w300, fontSize: 16.0);
+  }
 
-  static final screenBackground = LinearGradient(
-    colors: [
-      _top,
-      backgroundColor,
-      backgroundColor,
-      _bottom,
-    ],
-    begin: Alignment.topCenter,
-    end: Alignment.bottomCenter,
-    stops: [0.0, 0.15, 0.4, 1.0],
-    tileMode: TileMode.clamp,
-  );
-}
+  // TODO: if we want to change theme dynamically, implement set() methods and use
+  // ChangeNotifier.notifyListeners()
 
-class Dimens {
-  const Dimens();
-
-  static const imageWidth = 100.0;
-  static const imageHeight = 100.0;
-
-  static const buttonWidth = 60.0;
-  static const buttonHeight = 60.0;
-}
-
-class TextStyles {
-  const TextStyles();
-
-  static const TextStyle tabPrimary = TextStyle(
-      color: Colors.primaryColor,
-      fontFamily: 'Poppins',
-      fontWeight: FontWeight.w300,
-      fontSize: 28.0);
-
-  static const TextStyle tabSecondary = TextStyle(
-      color: Colors.primaryColor,
-      fontFamily: 'Poppins',
-      fontWeight: FontWeight.w300,
-      fontSize: 20.0);
-
-  static const TextStyle tabTertiary = TextStyle(
-      color: Colors.primaryColor,
-      fontFamily: 'Poppins',
-      fontWeight: FontWeight.w300,
-      fontSize: 16.0);
-
-  static const TextStyle tabLabel = TextStyle(
-      color: Colors.primaryColor,
-      fontFamily: 'Poppins',
-      fontWeight: FontWeight.w300,
-      fontSize: 16.0);
-}
-
-class Helper {
-  static Widget horizontalBorder() {
+  Widget buildHorizontalBorder() {
     return Container(
-      color: Colors.secondaryColor,
+      color: secondaryColor,
       width: 38.0,
       height: 1.0,
       margin: const EdgeInsets.symmetric(vertical: 8.0),
     );
+  }
+
+  // generates a ThemeData usable by Material based on our own primary and secondary colors
+  ThemeData get themeData {
+    var txtTheme = ThemeData.dark().textTheme.apply(fontFamily: 'Poppins');
+    var txtColor = txtTheme.bodyText1.color;
+    var colorScheme = ColorScheme(
+        brightness: Brightness.dark,
+        primary: primaryColor,
+        primaryVariant: primaryColor,
+        secondary: secondaryColor,
+        secondaryVariant: secondaryColor,
+        background: backgroundColor,
+        surface: backgroundColor,
+        onBackground: txtColor,
+        onSurface: txtColor,
+        onError: primaryColor,
+        onPrimary: primaryColor,
+        onSecondary: primaryColor,
+        error: badColor);
+
+    var t = ThemeData.from(textTheme: txtTheme, colorScheme: colorScheme).copyWith(
+        visualDensity: VisualDensity.adaptivePlatformDensity,
+        buttonColor: primaryColor,
+        cursorColor: primaryColor,
+        highlightColor: primaryColor,
+        toggleableActiveColor: primaryColor);
+
+    return t;
   }
 }

--- a/test/homepage_test.dart
+++ b/test/homepage_test.dart
@@ -1,11 +1,16 @@
+import 'package:flupresso/ui/theme.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:flupresso/main.dart';
+import 'package:provider/provider.dart';
 
 void main() {
   testWidgets('Main navigation works', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
+    // TODO: move multiprovider constructor to utils
+    await tester.pumpWidget(MultiProvider(providers: [
+      ChangeNotifierProvider<FluTheme>(create: (_) => FluTheme()),
+    ], child: MyApp()));
 
     // Verify that our counter starts at 0.
     expect(find.text('Espresso'), findsOneWidget);


### PR DESCRIPTION
Creates FluTheme change notifier and use Provider to pass fetch when needed. From lots of reading this is the "correct" way to pass down state and allow things to be properly rebuilt upon changes.

Pretty sure we should be something similar for the services but need to explore that more. Key is just that like React Flutter expects everything to be part of the UI tree so you have to nest these things at upper levels in order for state/stack to be properly managed.

Refs:
  https://flutter.dev/docs/development/data-and-backend/state-mgmt/simple
  https://blog.gskinner.com/archives/2020/04/flutter-create-custom-app-themes.html